### PR TITLE
20200327 conditional updates

### DIFF
--- a/style.css
+++ b/style.css
@@ -1518,12 +1518,12 @@ table td, table th {
 
 /***** Article *****/
 .article {
-  /*
-  * The article grid is defined this way to optimize readability:
-  * Sidebar | Content | Free space
-  * 17%     | 66%     | 17%
-
-  Testing out 75% (content/article) | 25% (sidebar) -- we can always revert back
+  /*
+  * The article grid is defined this way to optimize readability:
+  * Sidebar | Content | Free space
+  * 17%     | 66%     | 17%
+
+  Testing out 75% (content/article) | 25% (sidebar) -- we can always revert back
   */
   flex: 1 0 auto;
 }
@@ -2655,10 +2655,10 @@ table td, table th {
 }
 
 /***** Post *****/
-/*
-* The post grid is defined this way:
-* Content | Sidebar
-* 70%     | 30%
+/*
+* The post grid is defined this way:
+* Content | Sidebar
+* 70%     | 30%
 */
 .post {
   flex: 1;

--- a/templates/error_page.hbs
+++ b/templates/error_page.hbs
@@ -23,7 +23,7 @@
         <p class="caption-text compact">Philippe Mercier, The Sense of Sight, 1744 – 1747. Yale Center for British Art.</p>
       </div>
     {{/is}}
-    {{#is help_center.name 'JSTOR Support'}}
+    {{#is settings.product_name_text 'JSTOR'}}
       <div>
         <img src="{{asset 'stacks_update.png'}}" alt="Perspective of library stacks">
       </div>

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -5,7 +5,7 @@
   $("#htmlfooter").load("{{asset 'forum_footer.html'}}");
 </script>
 {{/is}}
-{{#is help_center.name 'JSTOR Support'}}
+{{#is settings.product_name_text 'JSTOR'}}
 <script>
   $("#htmlfooter").load("{{asset 'jstor_footer.html'}}");
 </script>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -30,13 +30,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <!-- End of status page code -->
 
-{{#is settings.product_name_text_label 'JSTOR'}}
+{{#is settings.product_name_text 'JSTOR'}}
 <header class="header header-jstor">
 {{else}}
 <header class="header">
 {{/is}}
   <div id="skipNav"><a class="show-on-focus" href="#main-content">Skip to Main Content</a></div>
-  {{#is settings.product_name_text_label 'JSTOR'}}
+  {{#is settings.product_name_text 'JSTOR'}}
   <div class="logo logo-jstor">
   {{else}}
   <div class="logo">

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -30,14 +30,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <!-- End of status page code -->
 
-{{#is help_center.name 'JSTOR Support'}}
+{{#is settings.product_name_text_label 'JSTOR'}}
 <header class="header header-jstor">
 {{else}}
 <header class="header">
 {{/is}}
   <div id="skipNav"><a class="show-on-focus" href="#main-content">Skip to Main Content</a></div>
-  {{#is help_center.name 'JSTOR Support'}}
-  <div class="logo logo-jstor"> 
+  {{#is settings.product_name_text_label 'JSTOR'}}
+  <div class="logo logo-jstor">
   {{else}}
   <div class="logo">
   {{/is}}


### PR DESCRIPTION
Replaced {{#is help_center.name 'JSTOR Support'}} with {{#is settings.product_name_text 'JSTOR'}} in the following templates:

footer.hbs
header.hbs
error_page.hbs

Publisher Support site loads all the same things as JSTOR support site on those pages, so I used the settings.product_name_text to identify those because they both have the value "JSTOR" there. 